### PR TITLE
#45-Fix fileconnector.readSpecifiedLines issue

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/ReadSpecifiedLines.java
+++ b/src/main/java/org/wso2/carbon/connector/ReadSpecifiedLines.java
@@ -46,9 +46,9 @@ public class ReadSpecifiedLines extends AbstractConnector implements Connector {
         String contentType = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                 FileConstants.CONTENT_TYPE);
         String from = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
-                FileConstants.FROM);
+                FileConstants.START);
         String to = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
-                FileConstants.TO);
+                FileConstants.END);
         FileObject fileObj = null;
         StandardFileSystemManager manager = null;
         try {

--- a/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
@@ -68,6 +68,8 @@ public final class FileConstants {
     public static final String DEFAULT_INCLUDE_PARENT_DIRECTORY = "false";
     public static final String FROM = "from";
     public static final String TO = "to";
+	public static final String START = "start";
+    public static final String END = "end";
     public static final String NEW_LINE = "\n";
     public static final String LAST_MODIFIED_TIME_START_TAG = "<result><lastModifiedTime>";
     public static final String LAST_MODIFIED_TIME_END_TAG = "</lastModifiedTime></result>";

--- a/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
@@ -68,7 +68,7 @@ public final class FileConstants {
     public static final String DEFAULT_INCLUDE_PARENT_DIRECTORY = "false";
     public static final String FROM = "from";
     public static final String TO = "to";
-	public static final String START = "start";
+    public static final String START = "start";
     public static final String END = "end";
     public static final String NEW_LINE = "\n";
     public static final String LAST_MODIFIED_TIME_START_TAG = "<result><lastModifiedTime>";


### PR DESCRIPTION
## Purpose
Currently, fileconnector.readSpecifiedLines function is not working properly. The reason for this issue is readSpecifiedLines.xml file uses start and end variable to divide lines. But when it comes to ReadSpecifiedLines.java file, it uses from and to variable values. That is why current function always gives a whole content of the specified file.

## Goals
Fix fileconnector.readSpecifiedLines not working issue

## Approach
Add new constant variables to FileConstants.java file and update ReadSpecifiedLines.java according to new constant variables.

## Issue Id
https://github.com/wso2-extensions/esb-connector-file/issues/45