### PR TITLE
Attach ftps file system options extracted from url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@
         <automation.framework.utils.version>4.4.2</automation.framework.utils.version>
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
-        <synapse.version>2.1.7-wso2v19</synapse.version>
+        <synapse.version>2.1.7-wso2v80</synapse.version>
+        <commons.vfs.version.version>2.2-wso2v4</commons.vfs.version.version>
         <carbon.mediation.version>4.6.19</carbon.mediation.version>
         <json.version>2.0.0.wso2v1</json.version>
         <org.testng.version>6.1.1</org.testng.version>
@@ -108,6 +109,11 @@
             <artifactId>org.wso2.carbon.integration.common.tests</artifactId>
             <version>${automation.framework.utils.version}</version>
             <!--<scope>compile</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.org.apache.commons</groupId>
+            <artifactId>commons-vfs2</artifactId>
+            <version>${commons.vfs.version.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.mediation</groupId>
@@ -197,11 +203,6 @@
             <groupId>org.wso2.orbit.commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>3.4.wso2v1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-vfs2</artifactId>
-            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/wso2/carbon/connector/FileAppend.java
+++ b/src/main/java/org/wso2/carbon/connector/FileAppend.java
@@ -33,6 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
 
@@ -96,7 +97,8 @@ public class FileAppend extends AbstractConnector implements Connector {
         BufferedReader reader = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(destination, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, destination, manager);
+            fileObj = manager.resolveFile(destination, fso);
             if (!fileObj.exists()) {
                 fileObj.createFile();
             }

--- a/src/main/java/org/wso2/carbon/connector/FileArchives.java
+++ b/src/main/java/org/wso2/carbon/connector/FileArchives.java
@@ -60,8 +60,10 @@ public class FileArchives extends AbstractConnector implements Connector {
      * @throws SynapseException
      */
     private boolean fileCompress(MessageContext messageContext, String source, String destination) {
-        StandardFileSystemManager manager;
-        FileSystemOptions opts = FileConnectorUtils.init(messageContext);
+        StandardFileSystemManager manager = FileConnectorUtils.getManager();
+        FileSystemOptions sourceFso = FileConnectorUtils.getFso(messageContext, source, manager);
+        FileSystemOptions destinationFso = FileConnectorUtils.getFso(messageContext, destination, manager);
+
         String inputContent = (String) ConnectorUtils.lookupTemplateParamater(messageContext, FileConstants.CONTENT);
         String fileName = (String) ConnectorUtils.lookupTemplateParamater(messageContext, FileConstants.FILE_NAME);
         if (StringUtils.isEmpty(fileName)) {
@@ -69,14 +71,13 @@ public class FileArchives extends AbstractConnector implements Connector {
         }
         ZipOutputStream outputStream = null;
         InputStream fileIn = null;
-        manager = FileConnectorUtils.getManager();
 
         if (StringUtils.isEmpty(source) && StringUtils.isEmpty(inputContent)) {
             log.error("The File location does not exist or Input content does not provide.");
             return false;
         }
         try {
-            FileObject destObj = manager.resolveFile(destination, opts);
+            FileObject destObj = manager.resolveFile(destination, destinationFso);
             if (StringUtils.isNotEmpty(inputContent)) {
                 outputStream = new ZipOutputStream(destObj.getContent().getOutputStream());
                 ZipEntry zipEntry = new ZipEntry(fileName);
@@ -86,7 +87,7 @@ public class FileArchives extends AbstractConnector implements Connector {
                 outputStream.closeEntry();
                 return true;
             }
-            FileObject fileObj = manager.resolveFile(source, opts);
+            FileObject fileObj = manager.resolveFile(source, sourceFso);
             if (!fileObj.exists()) {
                 log.error("File location does not exit.");
                 return false;

--- a/src/main/java/org/wso2/carbon/connector/FileCreate.java
+++ b/src/main/java/org/wso2/carbon/connector/FileCreate.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
 import org.codehaus.jettison.json.JSONException;
@@ -87,8 +88,8 @@ public class FileCreate extends AbstractConnector implements Connector {
             OutputStream out = null;
             manager = FileConnectorUtils.getManager();
             if (manager != null) {
-                FileObject sourceFile = manager.resolveFile(source
-                        , FileConnectorUtils.init(messageContext));
+                FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, source, manager);
+                FileObject sourceFile = manager.resolveFile(source, fso);
                 try {
                     if (FileConnectorUtils.isFolder(sourceFile)) {
                         sourceFile.createFolder();

--- a/src/main/java/org/wso2/carbon/connector/FileDelete.java
+++ b/src/main/java/org/wso2/carbon/connector/FileDelete.java
@@ -78,9 +78,9 @@ public class FileDelete extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, source, manager);
             // Create remote object
-            FileObject remoteFile = manager.resolveFile(source
-                    , FileConnectorUtils.init(messageContext));
+            FileObject remoteFile = manager.resolveFile(source, fso);
             if (remoteFile.exists()) {
                 if (remoteFile.getType() == FileType.FILE) {
                     //delete a file

--- a/src/main/java/org/wso2/carbon/connector/FileExist.java
+++ b/src/main/java/org/wso2/carbon/connector/FileExist.java
@@ -79,11 +79,12 @@ public class FileExist extends AbstractConnector implements Connector {
     private boolean isFileExist(String source, MessageContext messageContext) {
         boolean isFileExist = false;
         StandardFileSystemManager manager = null;
-        FileSystemOptions opt = FileConnectorUtils.init(messageContext);
+
         try {
             manager = FileConnectorUtils.getManager();
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, source, manager);
             // Create remote object
-            FileObject remoteFile = manager.resolveFile(source, opt);
+            FileObject remoteFile = manager.resolveFile(source, fso);
             if (remoteFile.exists()) {
                 isFileExist = true;
             }

--- a/src/main/java/org/wso2/carbon/connector/FileListZip.java
+++ b/src/main/java/org/wso2/carbon/connector/FileListZip.java
@@ -25,6 +25,7 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
@@ -55,11 +56,11 @@ public class FileListZip extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, source, manager);
             ResultPayloadCreate resultPayload = new ResultPayloadCreate();
 
             // Create remote object
-            FileObject remoteFile = manager.resolveFile(source
-                    , FileConnectorUtils.init(messageContext));
+            FileObject remoteFile = manager.resolveFile(source, fso);
             if (remoteFile != null && remoteFile.exists()) {
                 // open the zip file
                 InputStream input = remoteFile.getContent().getInputStream();

--- a/src/main/java/org/wso2/carbon/connector/FileRead.java
+++ b/src/main/java/org/wso2/carbon/connector/FileRead.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
@@ -46,7 +47,8 @@ public class FileRead extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(fileLocation, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            fileObj = manager.resolveFile(fileLocation, fso);
             if (fileObj.exists()) {
                 if (fileObj.getType() == FileType.FOLDER) {
                     FileObject[] children = fileObj.getChildren();

--- a/src/main/java/org/wso2/carbon/connector/FileSearch.java
+++ b/src/main/java/org/wso2/carbon/connector/FileSearch.java
@@ -70,8 +70,8 @@ public class FileSearch extends AbstractConnector implements Connector {
 		} else {
 			try {
 				manager = FileConnectorUtils.getManager();
-				FileSystemOptions opt = FileConnectorUtils.init(messageContext);
-				FileObject remoteFile = manager.resolveFile(source, opt);
+				FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, source, manager);
+				FileObject remoteFile = manager.resolveFile(source, fso);
 				if (remoteFile.exists()) {
 					FileObject[] children = remoteFile.getChildren();
 					OMFactory factory = OMAbstractFactory.getOMFactory();

--- a/src/main/java/org/wso2/carbon/connector/FileSend.java
+++ b/src/main/java/org/wso2/carbon/connector/FileSend.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
@@ -123,10 +124,11 @@ public class FileSend extends AbstractConnector implements Connector {
             manager = FileConnectorUtils.getManager();
             org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) messageContext).
                     getAxis2MessageContext();
-            fileObj = manager.resolveFile(address, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, address, manager);
+            fileObj = manager.resolveFile(address, fso);
             if (fileObj.getType() == FileType.FOLDER) {
                 address = address.concat(FileConstants.DEFAULT_RESPONSE_FILE);
-                fileObj = manager.resolveFile(address, FileConnectorUtils.init(messageContext));
+                fileObj = manager.resolveFile(address, fso);
             }
             // Get the message formatter.
             MessageFormatter messageFormatter = getMessageFormatter(axis2MessageContext);

--- a/src/main/java/org/wso2/carbon/connector/GetLastModifiedTime.java
+++ b/src/main/java/org/wso2/carbon/connector/GetLastModifiedTime.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
 import org.codehaus.jettison.json.JSONException;
@@ -51,7 +52,8 @@ public class GetLastModifiedTime extends AbstractConnector implements Connector 
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(fileLocation, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            fileObj = manager.resolveFile(fileLocation, fso);
             if (!fileObj.exists()) {
                 handleException("File/Folder does not exists in the location: " + fileLocation, messageContext);
             } else {

--- a/src/main/java/org/wso2/carbon/connector/GetSize.java
+++ b/src/main/java/org/wso2/carbon/connector/GetSize.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
@@ -51,7 +52,8 @@ public class GetSize extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(fileLocation, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            fileObj = manager.resolveFile(fileLocation, fso);
             if (!fileObj.exists() || fileObj.getType() != FileType.FILE) {
                 handleException("File does not exists, or source is not a file in the location:" + fileLocation, messageContext);
             } else {

--- a/src/main/java/org/wso2/carbon/connector/MergeFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/MergeFiles.java
@@ -54,8 +54,8 @@ public class MergeFiles extends AbstractConnector implements Connector {
                 FileConstants.NEW_FILE_LOCATION);
         String filePattern = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                 FileConstants.FILE_PATTERN);
-        FileSystemOptions options = FileConnectorUtils.init(messageContext);
-        boolean status = mergeFiles(fileLocation, destination, filePattern, options, messageContext);
+
+        boolean status = mergeFiles(fileLocation, destination, filePattern, messageContext);
         generateOutput(messageContext, status);
     }
 
@@ -67,7 +67,7 @@ public class MergeFiles extends AbstractConnector implements Connector {
      * @param messageContext    Message context.
      * @return Status true/false.
      */
-    private boolean mergeFiles(String source, String destination, String filePattern, FileSystemOptions options,
+    private boolean mergeFiles(String source, String destination, String filePattern,
                                MessageContext messageContext) {
         FileObject sourceFileObj = null;
         FileObject outputFileObj = null;
@@ -78,7 +78,10 @@ public class MergeFiles extends AbstractConnector implements Connector {
         byte[] fileBytes;
         try {
             manager = FileConnectorUtils.getManager();
-            sourceFileObj = manager.resolveFile(source, options);
+            FileSystemOptions sourceFso = FileConnectorUtils.getFso(messageContext, source, manager);
+            FileSystemOptions destinationFso = FileConnectorUtils.getFso(messageContext, destination, manager);
+
+            sourceFileObj = manager.resolveFile(source, sourceFso);
             if (!sourceFileObj.exists()) {
                 handleException("File/Folder does not exists in the location: " + source, messageContext);
             } else {
@@ -88,7 +91,7 @@ public class MergeFiles extends AbstractConnector implements Connector {
                         log.warn("Empty folder.");
                         handleException("Empty folder.", messageContext);
                     } else {
-                        outputFileObj = manager.resolveFile(destination, options);
+                        outputFileObj = manager.resolveFile(destination, destinationFso);
                         if (!outputFileObj.exists()) {
                             outputFileObj.createFile();
                         }

--- a/src/main/java/org/wso2/carbon/connector/ReadALine.java
+++ b/src/main/java/org/wso2/carbon/connector/ReadALine.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
@@ -51,7 +52,8 @@ public class ReadALine extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(fileLocation, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            fileObj = manager.resolveFile(fileLocation, fso);
             if (!fileObj.exists() || fileObj.getType() != FileType.FILE) {
                 handleException("File does not exists, or source is not a file in the location: " + fileLocation,
                         messageContext);

--- a/src/main/java/org/wso2/carbon/connector/ReadSpecifiedLines.java
+++ b/src/main/java/org/wso2/carbon/connector/ReadSpecifiedLines.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.synapse.MessageContext;
@@ -53,7 +54,8 @@ public class ReadSpecifiedLines extends AbstractConnector implements Connector {
         StandardFileSystemManager manager = null;
         try {
             manager = FileConnectorUtils.getManager();
-            fileObj = manager.resolveFile(fileLocation, FileConnectorUtils.init(messageContext));
+            FileSystemOptions fso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            fileObj = manager.resolveFile(fileLocation, fso);
             if (!fileObj.exists() || fileObj.getType() != FileType.FILE) {
                 handleException("File does not exists, or source is not a file in the location: " + fileLocation,
                         messageContext);

--- a/src/main/java/org/wso2/carbon/connector/SplitFile.java
+++ b/src/main/java/org/wso2/carbon/connector/SplitFile.java
@@ -74,8 +74,8 @@ public class SplitFile extends AbstractConnector implements Connector {
                 FileConstants.NUMBER_OF_LINES);
         String xpathExpression = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                 FileConstants.XPATH_EXPRESSION);
-        FileSystemOptions options = FileConnectorUtils.init(messageContext);
-        boolean resultStatus = splitFile(fileLocation, chunkSize, destination, numberOfLines, xpathExpression, options,
+
+        boolean resultStatus = splitFile(fileLocation, chunkSize, destination, numberOfLines, xpathExpression,
                 messageContext);
         generateOutput(messageContext, resultStatus);
     }
@@ -84,26 +84,27 @@ public class SplitFile extends AbstractConnector implements Connector {
      * @param fileLocation   Location of the source file.
      * @param chunkSize      size of the chunks to split the file.
      * @param destination    Location of the destination to write the splitted files.
-     * @param options        Init configuration options.
      * @param messageContext Message context.
      * @return Status true/false.
      */
     private boolean splitFile(String fileLocation, String chunkSize, String destination, String splitLength,
-                              String xpathExpression, FileSystemOptions options, MessageContext messageContext) {
+                              String xpathExpression, MessageContext messageContext) {
         FileObject sourceFileObj = null;
         try {
             manager = FileConnectorUtils.getManager();
-            sourceFileObj = manager.resolveFile(fileLocation, options);
+            FileSystemOptions sourceFso = FileConnectorUtils.getFso(messageContext, fileLocation, manager);
+            FileSystemOptions destinationFso = FileConnectorUtils.getFso(messageContext, destination, manager);
+            sourceFileObj = manager.resolveFile(fileLocation, sourceFso);
             if (!sourceFileObj.exists() || sourceFileObj.getType() != FileType.FILE) {
                 handleException("File does not exists, or source is not a file in the location: " + fileLocation,
                         messageContext);
             } else {
                 if (StringUtils.isNotEmpty(splitLength)) {
-                    splitByLines(sourceFileObj, destination, splitLength, options, messageContext);
+                    splitByLines(sourceFileObj, destination, splitLength, destinationFso, messageContext);
                 } else if (StringUtils.isNotEmpty(chunkSize)) {
-                    splitByChunkSize(sourceFileObj, destination, chunkSize, options, messageContext);
+                    splitByChunkSize(sourceFileObj, destination, chunkSize, destinationFso, messageContext);
                 } else if (StringUtils.isNotEmpty(xpathExpression)) {
-                    splitByXPathExpression(sourceFileObj, destination, xpathExpression, options, messageContext);
+                    splitByXPathExpression(sourceFileObj, destination, xpathExpression, destinationFso, messageContext);
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/org/wso2/carbon/connector/util/FileUnzipUtil.java
+++ b/src/main/java/org/wso2/carbon/connector/util/FileUnzipUtil.java
@@ -45,12 +45,15 @@ public class FileUnzipUtil {
         OMNamespace ns = factory.createOMNamespace(FileConstants.FILECON, FileConstants.NAMESPACE);
         OMElement result = factory.createOMElement(FileConstants.RESULT, ns);
         boolean resultStatus = false;
-        FileSystemOptions opts = FileConnectorUtils.init(messageContext);
+
         try {
             manager = FileConnectorUtils.getManager();
+            FileSystemOptions sourceFso = FileConnectorUtils.getFso(messageContext, source, manager);
+            FileSystemOptions destinationFso = FileConnectorUtils.getFso(messageContext, destDirectory, manager);
+
             // Create remote object
-            FileObject remoteFile = manager.resolveFile(source, opts);
-            FileObject remoteDesFile = manager.resolveFile(destDirectory, opts);
+            FileObject remoteFile = manager.resolveFile(source, sourceFso);
+            FileObject remoteDesFile = manager.resolveFile(destDirectory, destinationFso);
             // File destDir = new File(destDirectory);
             if (remoteFile.exists()) {
                 if (!remoteDesFile.exists()) {
@@ -66,14 +69,14 @@ public class FileUnzipUtil {
                         // boolean testResult;
                         String filePath = destDirectory + File.separator + entry.getName();
                         // Create remote object
-                        FileObject remoteFilePath = manager.resolveFile(filePath, opts);
+                        FileObject remoteFilePath = manager.resolveFile(filePath, destinationFso);
                         if (log.isDebugEnabled()) {
                             log.debug("The created path is " + remoteFilePath.toString());
                         }
                         try {
                             if (!entry.isDirectory()) {
                                 // if the entry is a file, extracts it
-                                extractFile(zipIn, filePath, opts);
+                                extractFile(zipIn, filePath, destinationFso);
                                 OMElement messageElement = factory.createOMElement(FileConstants.FILE
                                         , ns);
                                 messageElement.setText(entry.getName() + " | status:" + "true");


### PR DESCRIPTION
The code segment used to set ssl and other ftps parameters had been moved from commons-vfs library to synapse and since the file connector calls commons-vfs directly it misses setting those configs.
This commit adds that code segment to FileConnectorUtils.

Fixes wso2-extensions/esb-connector-file#54