### PR TITLE
close fileObjects while looping over merging files (children) in a folder

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/MergeFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/MergeFiles.java
@@ -113,6 +113,11 @@ public class MergeFiles extends AbstractConnector implements Connector {
                                 bufferedOutputStream.flush();
                                 outputStream.flush();
                             }
+                            try {
+                                child.close();
+                            } catch (IOException e) {
+                                log.warn("Error while closing a file in the source folder: " + e.getMessage(), e);
+                            }
                         }
                     }
                     status = true;


### PR DESCRIPTION
## Purpose
On a windows system, after merging files with the fileconnector's merge functionality, the files can't be deleted as long as the WSO2 application is running. When the WSO2 application has stopped, the files can be deleted again.

## Goals
To resolve the probleme all files that are being merged should not remain locked by the WSO2 application when they are merged. 

## Approach
While looping over the files that are being merged a fileObject os created. At the end of each iteration (over a file) the fileObject needs to be closed ( fileObject.close() ).

## User stories
Files that are merged, should be deleted afterwards.

## Release note
Fix fileconnector.merge. Merged files no longer remain locked by the application.