### PR TITLE
check whether filePattern matches before diving into the next recursion

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/FileCopy.java
+++ b/src/main/java/org/wso2/carbon/connector/FileCopy.java
@@ -1,20 +1,20 @@
 /*
-* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the "License"); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-*http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.connector;
 
 import org.apache.axiom.om.OMElement;
@@ -111,7 +111,14 @@ public class FileCopy extends AbstractConnector implements Connector {
                 FileObject[] children = souFile.getChildren();
                 for (FileObject child : children) {
                     if (child.getType() == FileType.FILE) {
-                        copy(child, destination, filePattern, destinationFso, messageContext);
+                        if (filePattern != null) {
+                            FilePattenMatcher patternMatcher = new FilePattenMatcher(filePattern);
+                            if (patternMatcher.validate(child.getName().getBaseName())) {
+                                copy(child, destination, filePattern, destinationFso, messageContext);
+                            }
+                        } else {
+                            copy(child, destination, filePattern, destinationFso, messageContext);
+                        }
                     } else if (child.getType() == FileType.FOLDER) {
                         String[] urlParts = source.split("\\?");
                         if (urlParts.length > 1) {
@@ -187,7 +194,7 @@ public class FileCopy extends AbstractConnector implements Connector {
             }
         } catch (IOException e) {
             log.error("Error occurred while copying a file. " + e.getMessage(), e);
-			handleException("Error occurred while copying a file.", e, messageContext);
+            handleException("Error occurred while copying a file.", e, messageContext);
         } finally {
             manager.close();
         }


### PR DESCRIPTION
## Purpose
This increases the efficiency of copying 1-2 files by filePattern from a folder containing ~1750 files by factors 15 - 200 depending on the connection being used (ftp://localhost - ftps://WAN server)!

## Goals
The trick is not descend into the copy method again if the childs filename does not match the filePattern.

## Approach
see goals

## User stories

## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning
