### PR TITLE
Add filePattern check when copying files in file connector

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/FileCopy.java
+++ b/src/main/java/org/wso2/carbon/connector/FileCopy.java
@@ -111,7 +111,14 @@ public class FileCopy extends AbstractConnector implements Connector {
                 FileObject[] children = souFile.getChildren();
                 for (FileObject child : children) {
                     if (child.getType() == FileType.FILE) {
-                        copy(child, destination, filePattern, destinationFso, messageContext);
+                        if (filePattern != null) {
+                            FilePattenMatcher patternMatcher = new FilePattenMatcher(filePattern);
+                            if (patternMatcher.validate(child.getName().getBaseName())) {
+                                copy(child, destination, filePattern, destinationFso, messageContext);
+                            }
+                        } else {
+                            copy(child, destination, filePattern, destinationFso, messageContext);
+                        }
                     } else if (child.getType() == FileType.FOLDER) {
                         String[] urlParts = source.split("\\?");
                         if (urlParts.length > 1) {


### PR DESCRIPTION
## Purpose
This PR will increases the copying efficiency when filePattern is there.

This increases the efficiency of copying 1-2 files by filePattern from a
folder containing ~1750 files by factors 15 - 200 depending on the connection being used (ftp://localhost - ftps://WAN server). The trick is not descend into the copy method again if the child's filename does not match the filePattern.

Resolves: https://github.com/wso2-extensions/esb-connector-file/issues/74