### PR TITLE
Improve file connector append operation

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/FileAppend.java
+++ b/src/main/java/org/wso2/carbon/connector/FileAppend.java
@@ -103,20 +103,22 @@ public class FileAppend extends AbstractConnector implements Connector {
                 fileObj.createFile();
             }
             reader = new BufferedReader(new InputStreamReader(fileObj.getContent().getInputStream()));
-            List<String> lines = reader.lines().collect(Collectors.toList());
-            if (StringUtils.isNotEmpty(position) && Integer.parseInt(position) <= lines.size()
-                    && Integer.parseInt(position) > 0) {
-                lines.add(Integer.parseInt(position) - 1, content);
-                out = fileObj.getContent().getOutputStream();
-                if(StringUtils.isEmpty(encoding)) {
-                    IOUtils.writeLines(lines, null, out, DEFAULT_ENCODING);
-                } else {
-                    IOUtils.writeLines(lines, null, out, encoding);
+            if (StringUtils.isNotEmpty(position)) {
+                List<String> lines = reader.lines().collect(Collectors.toList());
+                if (Integer.parseInt(position) <= lines.size()
+                        && Integer.parseInt(position) > 0) {
+                    lines.add(Integer.parseInt(position) - 1, content);
+                    out = fileObj.getContent().getOutputStream();
+                    if (StringUtils.isEmpty(encoding)) {
+                        IOUtils.writeLines(lines, null, out, DEFAULT_ENCODING);
+                    } else {
+                        IOUtils.writeLines(lines, null, out, encoding);
+                    }
+                    return true;
+                } else if (StringUtils.isNotEmpty(position)) {
+                    log.warn("Position is greater/less than the file size. " +
+                            "Appending the content at the end of the file");
                 }
-                return true;
-            } else if(StringUtils.isNotEmpty(position)) {
-                log.warn("Position is greater/less than the file size. " +
-                        "Appending the content at the end of the file");
             }
             out = fileObj.getContent().getOutputStream(true);
             if (StringUtils.isEmpty(encoding)) {


### PR DESCRIPTION
## Purpose
This PR improves the performance of the file connector append operation. When appending content to the end of the file (default config) we do not need to read the content of the file line by line.
The file content should be read, only when a file position is configured to append content.

Fixes https://github.com/wso2/product-ei/issues/5390
