### PR TITLE
Improve recursive file listing with flat and hierarchical responses 

### DIFF
--- a/src/main/resources/functions/listFiles.xml
+++ b/src/main/resources/functions/listFiles.xml
@@ -20,6 +20,7 @@
     <parameter name="directoryPath" description="The path to the directory to list files"/>
     <parameter name="matchingPattern" description="Pattern to match when listing files"/>
     <parameter name="recursive" description="List files in sub-directories"/>
+    <parameter name="responseFormat" description="Format to list the files in response" />
     <parameter name="sortingAttribute" description="Sort files when listing" />
     <parameter name="sortingOrder" description="File sorting order"/>
     <sequence>

--- a/src/main/resources/uischema/listFiles.json
+++ b/src/main/resources/uischema/listFiles.json
@@ -64,6 +64,18 @@
                     "required": "false",
                     "helpTip": "List files in sub-directories"
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "responseFormat",
+                    "displayName": "Response Format",
+                    "inputType": "comboOrExpression",
+                    "comboValues": ["Hierarchical", "Flat"],
+                    "defaultValue": "Hierarchical",
+                    "required": "true",
+                    "helpTip": "Response will be formatted as per this attribute."
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose

Fix issue when listing files in sub-folders when a pattern is present and add ability to get a flat response. 
Fixes: https://github.com/wso2/micro-integrator/issues/2324

Approach: 
Sub folder files were not visible due to the fact that pattern matching has omitted the sub-folders. This PR fixes that issue. 
Now you can select how the output should be - `hierarchical` or `flat` when you configure the operation. 

Response will look like below

**Hierarchical**
```
<listFilesResult>
	<success>true</success>
	<directory name="test">
		<directory name="newFolder">
			<directory name="hasitha">
				<file>test4.xml</file>
			</directory>
			<file>test3.xml</file>
		</directory>
		<file>test1.xml</file>
		<file>test2.xml</file>
	</directory>
</listFilesResult>
 ```

**Flat** 

```
<listFilesResult>
	<success>true</success>
	<files>
		<file>
			<name>test4.xml</name>
			<path>/Users/hasitha/temp/mi-deployment/test/newFolder/hasitha/test4.xml</path>
		</file>
		<file>
			<name>test3.xml</name>
			<path>/Users/hasitha/temp/mi-deployment/test/newFolder/test3.xml</path>
		</file>
		<file>
			<name>test1.xml</name>
			<path>/Users/hasitha/temp/mi-deployment/test/test1.xml</path>
		</file>
		<file>
			<name>test2.xml</name>
			<path>/Users/hasitha/temp/mi-deployment/test/test2.xml</path>
		</file>
	</files>
</listFilesResult>
```

<img width="1394" alt="Screenshot 2021-06-05 at 15 21 20" src="https://user-images.githubusercontent.com/4967046/120888335-64a3c780-c615-11eb-9977-5ae560aa1552.png">

