### PR TITLE
Add permission skip option to move operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.fileconnector</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <name>WSO2 Carbon - Mediation Library Connector For fileconnector</name>
     <url>http://wso2.org</url>
     <profiles>

--- a/src/main/java/org/wso2/carbon/connector/util/FileConnectorUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/util/FileConnectorUtils.java
@@ -122,6 +122,8 @@ public class FileConnectorUtils {
                 (messageContext, FileConstants.SET_STRICT_HOST_KEY_CHECKING);
         String setUserDirIsRoot = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                 FileConstants.SET_USER_DIRISROOT);
+        String setAvoidPermission = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                FileConstants.SET_AVOID_PERMISSION);
 
         if (log.isDebugEnabled()) {
             log.debug("File init starts with " + setTimeout + "," + setPassiveMode + "," +
@@ -223,6 +225,9 @@ public class FileConnectorUtils {
                 throw new SynapseTaskException("Error while configuring a " +
                         "setSoTimeout", e);
             }
+        }
+        if (!StringUtils.isEmpty(setAvoidPermission)) {
+            SftpFileSystemConfigBuilder.getInstance().setAvoidPermissionCheck(opts, setAvoidPermission.trim());
         }
         if (log.isDebugEnabled()) {
             log.debug("FileConnector configuration is completed.");

--- a/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/FileConstants.java
@@ -40,6 +40,7 @@ public final class FileConstants {
     public static final String SET_SO_TIMEOUT = "setSoTimeout";
     public static final String SET_STRICT_HOST_KEY_CHECKING = "setStrictHostKeyChecking";
     public static final String SET_USER_DIRISROOT = "setUserDirIsRoot";
+    public static final String SET_AVOID_PERMISSION = "setAvoidPermission";
     public static final String SFTP_IDENTITIES = "sftpIdentities";
     public static final String SFTP_IDENTITY_PASSPHRASE = "sftpIdentityPassphrase";
     public static final String SOURCE_SFTP_IDENTITIES = "sourceSftpIdentities";

--- a/src/main/resources/file/filemove-template.xml
+++ b/src/main/resources/file/filemove-template.xml
@@ -25,6 +25,7 @@
     <parameter name="setSoTimeout" description="Sets the socket timeout for the FTP client."/>
     <parameter name="setStrictHostKeyChecking" description="Sets the host key checking to use."/>
     <parameter name="setUserDirIsRoot" description="Sets the whether to use the user directory as root."/>
+    <parameter name="setAvoidPermission" description="Sets whether to avoid file permission check."/>
     <parameter name="includeParentDirectory"
                description="Boolean type, indicating whether the parent directory will include or not."/>
     <parameter name="filePattern" description="The pattern of the files to be copied."/>
@@ -48,6 +49,7 @@
         <property name="sourceSftpIdentityPassphrase" expression="$func:sourceSftpIdentityPassphrase"/>
         <property name="targetSftpIdentities" expression="$func:targetSftpIdentities"/>
         <property name="targetSftpIdentityPassphrase" expression="$func:targetSftpIdentityPassphrase"/>
+        <property name="setAvoidPermission" expression="$func:setAvoidPermission"/>
         <class name="org.wso2.carbon.connector.FileMove"/>
     </sequence>
 </template>

--- a/src/main/resources/uischema/move.json
+++ b/src/main/resources/uischema/move.json
@@ -83,6 +83,17 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "setAvoidPermission",
+                    "displayName": "Avoid Permissions",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Set to true if you want to avoid permission check."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "setStrictHostKeyChecking",
                     "displayName": "Strict Host Key Checking",
                     "inputType": "stringOrExpression",


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2-extensions/esb-connector-file/issues/76

## Goals
A new property called `setAvoidPermission` is added to the file connector move operation.

## User stories

By default, the `fileconnector.move` operation checks whether the user has permission to access the location of the files (the source location or the destination). However, since the system is reading files in an external server through the SFTP connection, this permission check is not required and should be avoided. To skip this check you can use the property `<setAvoidPermission>true</setAvoidPermission>`.

```xml
<fileconnector.move>
  <source>sftp://sftpuser:xxx@127.0.0.1/sftpuser/test.txt</source>
  <destination>sftp://sftpuser:xxx@127.0.0.1/sftpuser/test-folder</destination>
  <setAvoidPermission>true</setAvoidPermission>
</fileconnector.move>
```