### PR TITLE
Bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.file</artifactId>
-    <version>4.0.8</version>
+    <version>4.0.9</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For esb-connector-file</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/connector/connection/SFTPFileSystemSetup.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/SFTPFileSystemSetup.java
@@ -43,6 +43,7 @@ public class SFTPFileSystemSetup implements ProtocolBasedFileSystemSetup {
         SftpFileSystemConfigBuilder sftpConfigBuilder = SftpFileSystemConfigBuilder.getInstance();
 
         try {
+            sftpConfigBuilder.setAvoidPermissionCheck(fso, sftpConnectionConfig.getAvoidPermissionCheck());
             sftpConfigBuilder.setTimeout(fso, sftpConnectionConfig.getSessionTimeout());
 
             if (sftpConnectionConfig.isStrictHostKeyChecking()) {

--- a/src/main/java/org/wso2/carbon/connector/exception/FileLockException.java
+++ b/src/main/java/org/wso2/carbon/connector/exception/FileLockException.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.connector.exception;
 
 import org.wso2.carbon.connector.core.ConnectException;
+import org.wso2.carbon.connector.utils.Utils;
 
 /**
  * Represents exception thrown when unable to
@@ -28,7 +29,7 @@ public class FileLockException extends ConnectException {
 
     public FileLockException(String message) {
 
-        super(message);
+        super(Utils.maskURLPassword(message));
     }
 
     public FileLockException(String message, Throwable cause) {

--- a/src/main/java/org/wso2/carbon/connector/exception/FileOperationException.java
+++ b/src/main/java/org/wso2/carbon/connector/exception/FileOperationException.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.connector.exception;
 
 import org.wso2.carbon.connector.core.ConnectException;
+import org.wso2.carbon.connector.utils.Utils;
 
 /**
  * Represents any exception thrown by the connector in general.
@@ -28,11 +29,11 @@ public class FileOperationException extends ConnectException {
 
     public FileOperationException(String message) {
 
-        super(message);
+        super(Utils.maskURLPassword(message));
     }
 
     public FileOperationException(String message, Throwable cause) {
 
-        super(cause, message);
+        super(cause, Utils.maskURLPassword(message));
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/exception/IllegalPathException.java
+++ b/src/main/java/org/wso2/carbon/connector/exception/IllegalPathException.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.connector.exception;
 
 import org.wso2.carbon.connector.core.ConnectException;
+import org.wso2.carbon.connector.utils.Utils;
 
 /**
  * Represents exception thrown when
@@ -28,7 +29,7 @@ public class IllegalPathException extends ConnectException {
 
     public IllegalPathException(String message) {
 
-        super(message);
+        super(Utils.maskURLPassword(message));
     }
 
     public IllegalPathException(String message, Throwable cause) {

--- a/src/main/java/org/wso2/carbon/connector/operations/CheckFileExist.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CheckFileExist.java
@@ -145,6 +145,7 @@ public class CheckFileExist extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/CompressFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CompressFiles.java
@@ -301,6 +301,7 @@ public class CompressFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/CopyFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CopyFiles.java
@@ -276,6 +276,7 @@ public class CopyFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/CreateDirectory.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CreateDirectory.java
@@ -99,6 +99,7 @@ public class CreateDirectory extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/DeleteFileOrFolder.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/DeleteFileOrFolder.java
@@ -140,6 +140,7 @@ public class DeleteFileOrFolder extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ExploreZipFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ExploreZipFile.java
@@ -148,6 +148,7 @@ public class ExploreZipFile extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
@@ -228,12 +228,15 @@ public class FileConfig extends AbstractConnector implements ManagedLifecycle {
                 lookupTemplateParamater(msgContext, Const.PRIVATE_KEY_FILE_PATH);
         String privateKeyPassword = (String) ConnectorUtils.
                 lookupTemplateParamater(msgContext, Const.PRIVATE_KEY_PASSWORD);
+        String setAvoidPermission = (String) ConnectorUtils.
+                lookupTemplateParamater(msgContext, Const.SET_AVOID_PERMISSION);
 
         config.setConnectionTimeout(sftpConnectionTimeout);
         config.setSessionTimeout(sftpSessionTimeout);
         config.setStrictHostKeyChecking(strictHostKeyChecking);
         config.setPrivateKeyFilePath(privateKeyFilePath);
         config.setPrivateKeyPassword(privateKeyPassword);
+        config.setAvoidPermissionCheck(setAvoidPermission);
     }
 
     /**

--- a/src/main/java/org/wso2/carbon/connector/operations/ListFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ListFiles.java
@@ -305,6 +305,7 @@ public class ListFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/MergeFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MergeFiles.java
@@ -239,6 +239,7 @@ public class MergeFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/MoveFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MoveFiles.java
@@ -332,6 +332,7 @@ public class MoveFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
@@ -211,7 +211,7 @@ public class ReadFile extends AbstractConnector {
         config.enableLock = Utils.
                 lookUpBooleanParam(msgCtx, ENABLE_LOCK_PARAM, false);
         config.readMode = FileReadMode.fromString(Utils.
-                lookUpStringParam(msgCtx, READ_MODE_PARAM, FileReadMode.COMPLETE_FILE.toString()));
+                lookUpStringParam(msgCtx, READ_MODE_PARAM, FileReadMode.COMPLETE_FILE.getMode()));
         config.includeResultTo = Utils.
                 lookUpStringParam(msgCtx, INCLUDE_RESULT_TO, Const.MESSAGE_BODY);
         config.resultPropertyName = Utils.

--- a/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
@@ -323,6 +323,7 @@ public class ReadFile extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/RenameFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RenameFiles.java
@@ -148,6 +148,7 @@ public class RenameFiles extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SplitFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SplitFile.java
@@ -537,6 +537,7 @@ public class SplitFile extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/UnzipFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/UnzipFile.java
@@ -255,6 +255,7 @@ public class UnzipFile extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
@@ -234,6 +234,7 @@ public class WriteFile extends AbstractConnector {
      * @param errorDetail Error detail
      */
     private void handleError(MessageContext msgCtx, Exception e, Error error, String errorDetail) {
+        errorDetail = Utils.maskURLPassword(errorDetail);
         Utils.setError(OPERATION_NAME, msgCtx, e, error, errorDetail);
         handleException(errorDetail, e, msgCtx);
     }

--- a/src/main/java/org/wso2/carbon/connector/pojo/SFTPConnectionConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/pojo/SFTPConnectionConfig.java
@@ -45,6 +45,8 @@ public class SFTPConnectionConfig extends RemoteServerConfig {
     //Passphrase of the private key
     private String privateKeyPassword;
 
+    private String setAvoidPermission;
+
     /**
      * Create a SFTPConnectionConfig
      * with default values set
@@ -53,6 +55,7 @@ public class SFTPConnectionConfig extends RemoteServerConfig {
         this.strictHostKeyChecking = false;
         this.connectionTimeout = 100000;
         this.sessionTimeout = 150000;
+        this.setAvoidPermission = "false";
     }
 
     public int getConnectionTimeout() {
@@ -110,6 +113,16 @@ public class SFTPConnectionConfig extends RemoteServerConfig {
     public void setPrivateKeyPassword(String privateKeyPassword) {
         if (StringUtils.isNotEmpty(privateKeyPassword)) {
             this.privateKeyPassword = privateKeyPassword;
+        }
+    }
+
+    public String getAvoidPermissionCheck() {
+        return setAvoidPermission;
+    }
+
+    public void setAvoidPermissionCheck(String setAvoidPermission) {
+        if (StringUtils.isNotBlank(setAvoidPermission)) {
+            this.setAvoidPermission = setAvoidPermission;
         }
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/utils/Const.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Const.java
@@ -36,6 +36,7 @@ public final class Const {
     public static final String WORKING_DIR = "workingDir";
     public static final String FILE_LOCK_SCHEME = "fileLockScheme";
     public static final String MAX_FAILURE_RETRY_COUNT = "maxFailureRetryCount";
+    public static final String SET_AVOID_PERMISSION = "setAvoidPermission";
 
     public static final String HOST = "host";
     public static final String PORT = "port";

--- a/src/main/java/org/wso2/carbon/connector/utils/Utils.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Utils.java
@@ -36,7 +36,12 @@ import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.exception.InvalidConfigurationException;
 import org.wso2.carbon.connector.pojo.FileOperationResult;
 
+import java.util.regex.Matcher;
+
 import javax.xml.stream.XMLStreamException;
+
+import static org.apache.synapse.SynapseConstants.PASSWORD_PATTERN;
+import static org.apache.synapse.SynapseConstants.URL_PATTERN;
 
 /**
  * Util methods related to file connector operations
@@ -261,5 +266,23 @@ public class Utils {
         ((Axis2MessageContext) msgContext).getAxis2MessageContext().
                 removeProperty(PassThroughConstants.NO_ENTITY_BODY);
         soapBody.addChild(resultElement);
+    }
+
+    /**
+     * Mask the password of the connection url with ***
+     *
+     * @param url the actual url
+     * @return the masked url
+     */
+    public static String maskURLPassword(String url) {
+
+        final Matcher urlMatcher = URL_PATTERN.matcher(url);
+        String maskUrl;
+        if (urlMatcher.find()) {
+            final Matcher pwdMatcher = PASSWORD_PATTERN.matcher(url);
+            maskUrl = pwdMatcher.replaceFirst(":***@");
+            return maskUrl;
+        }
+        return url;
     }
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -46,6 +46,7 @@
 	<parameter name="strictHostKeyChecking" description="Host key checking to use. If true it will use 'yes'"/>
 	<parameter name="privateKeyFilePath" description="path to private key file"/>
 	<parameter name="privateKeyPassword" description="Passphrase of the private key"/>
+	<parameter name="setAvoidPermission" description="Sets whether to avoid file permission check."/>
 	<sequence>
 		<property name="name" expression="$func:name"/>
 		<class name="org.wso2.carbon.connector.operations.FileConfig" />

--- a/src/main/resources/uischema/sftp.json
+++ b/src/main/resources/uischema/sftp.json
@@ -91,6 +91,18 @@
                     "required": "false",
                     "helpTip": "Working directory. File paths in operations should be given w.r.t this folder"
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "setAvoidPermission",
+                    "displayName": "Avoid Permissions",
+                    "inputType": "comboOrExpression",
+                    "comboValues": ["false", "true"],
+                    "defaultValue": "false",
+                    "required": "false",
+                    "helpTip": "Set to true if you want to avoid permission check."
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
1. Fixes https://github.com/wso2/micro-integrator/issues/2330
2. Fixes https://github.com/wso2-extensions/esb-connector-file/issues/173
3. Fixes https://github.com/wso2-extensions/esb-connector-file/issues/76

## Goals
1. Mask passwords in error logs and responses.
2. Set `complete file` as the default read mode.
3. A new property called setAvoidPermission is added to the file connector move operation.

## User stories
1. Error logs and responses will have masked passwords.
2. When the readMode is not set, the read operation will read the complete file.
3. By default, the file operation checks whether the user has permission to access the location of the files (the source location or the destination). However, since the system is reading files in an external server through the SFTP connection, this permission check is not required and should be avoided. To skip this check you can use the property <setAvoidPermission>true</setAvoidPermission>.
```xml
<file.init>
        <connectionType>SFTP</connectionType>
        <password>123</password>
        <host>localhost</host>
        <fileLockScheme>Local</fileLockScheme>
        <sftpConnectionTimeout>100000</sftpConnectionTimeout>
        <userDirIsRoot>false</userDirIsRoot>
        <port>22</port>
        <name>FILE_CONNECTION_1</name>
        <sftpSessionTimeout>150000</sftpSessionTimeout>
        <username>user</username>
        <setAvoidPermission>true</setAvoidPermission>
</file.init>
```