### PR TITLE
Convert value of the 'setCharacterEncoding' property from Boolean to String

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ReadFile.java
@@ -425,7 +425,7 @@ public class ReadFile extends AbstractConnector {
             }
         }
         ((Axis2MessageContext) msgContext).getAxis2MessageContext().
-                setProperty(Const.SET_CHARACTER_ENCODING, true);
+                setProperty(Const.SET_CHARACTER_ENCODING, "true");
         ((Axis2MessageContext) msgContext).getAxis2MessageContext().
                 setProperty(Constants.Configuration.CHARACTER_SET_ENCODING, charSetEnc);
     }


### PR DESCRIPTION
Earlier, the message context property “setCharacterEncoding” has been assigned with a Boolean value. However, in these places [2], [3], we are casting this property’s value to a String to get it as a string. As java.lang.Boolean cannot be cast to java.lang.String, an exception is thrown. This PR fixes https://github.com/wso2-extensions/esb-connector-file/issues/175

