### PR TITLE
Remove IO operations to improve performance

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/CheckFileExist.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CheckFileExist.java
@@ -76,9 +76,13 @@ public class CheckFileExist extends AbstractConnector {
             FileSystemManager fsManager = fileSystemHandler.getFsManager();
             FileSystemOptions fso = fileSystemHandler.getFsOptions();
             fileObject = fsManager.resolveFile(filePath, fso);
-            fsManager.getFilesCache().removeFile(fileObject.getFileSystem(),  fileObject.getName());
-            fsManager.getFilesCache().removeFile(fileObject.getParent().getFileSystem(),  fileObject.getParent().getName());
-            fileObject = fsManager.resolveFile(filePath, fso);
+            /*
+                Temporarily reverting this fix with expensive file system resolve calls.
+                No git issue is pointed in this commit. So  we cannot find a better solution which resolve both issues.
+             */
+            //fsManager.getFilesCache().removeFile(fileObject.getFileSystem(),  fileObject.getName());
+            //fsManager.getFilesCache().removeFile(fileObject.getParent().getFileSystem(),  fileObject.getParent().getName());
+            //fileObject = fsManager.resolveFile(filePath, fso);
 
 
             String operationResult;


### PR DESCRIPTION
## Purpose
> Remove expensive I/O operations to improve the performance.
Fixes wso2/api-manager/issues/523