### PR TITLE
Fix absolute paths not working issue with sftp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <repository>
             <id>wso2-nexus</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -356,7 +356,7 @@
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -366,7 +366,7 @@
         <repository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -380,12 +380,12 @@
         <repository>
             <id>nexus-releases</id>
             <name>WSO2 Release Distribution Repository</name>
-            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+            <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 </project>

--- a/src/main/java/org/wso2/carbon/connector/connection/SFTPFileSystemSetup.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/SFTPFileSystemSetup.java
@@ -41,10 +41,10 @@ public class SFTPFileSystemSetup implements ProtocolBasedFileSystemSetup {
 
         SFTPConnectionConfig sftpConnectionConfig = (SFTPConnectionConfig) fsConfig.getRemoteServerConfig();
         SftpFileSystemConfigBuilder sftpConfigBuilder = SftpFileSystemConfigBuilder.getInstance();
-
         try {
             sftpConfigBuilder.setAvoidPermissionCheck(fso, sftpConnectionConfig.getAvoidPermissionCheck());
             sftpConfigBuilder.setTimeout(fso, sftpConnectionConfig.getSessionTimeout());
+            sftpConfigBuilder.setUserDirIsRoot(fso, sftpConnectionConfig.isUserDirIsRoot());
 
             if (sftpConnectionConfig.isStrictHostKeyChecking()) {
                 sftpConfigBuilder.setStrictHostKeyChecking(fso, "yes");


### PR DESCRIPTION
## Purpose
> The SFTP connections are initialise with FtpFileSystemConfigBuilder.getInstance().setUserDirIsRoot(options, false) to make the file writes available from root directory

Fixes: https://github.com/wso2-extensions/esb-connector-file/issues/187

https://commons.apache.org/proper/commons-vfs/filesystems.html

