### PR TITLE
Clear connection cache once session timed out

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/utils/Const.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Const.java
@@ -37,6 +37,7 @@ public final class Const {
     public static final String FILE_LOCK_SCHEME = "fileLockScheme";
     public static final String MAX_FAILURE_RETRY_COUNT = "maxFailureRetryCount";
     public static final String SET_AVOID_PERMISSION = "setAvoidPermission";
+    public static final String CONNECTION_POOL_TIMEOUT = "connectionPoolTimeout";
 
     public static final String HOST = "host";
     public static final String PORT = "port";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -23,6 +23,7 @@
 	<parameter name="workingDir" description="Working directory. File paths in operations should be given w.r.t this folder"/>
 	<parameter name="fileLockScheme" description="File locking behaviour to use. Local or Cluster" />
 	<parameter name="maxFailureRetryCount" description="Max retry count upon file operation failure"/>
+	<parameter name="connectionPoolTimeout" description="Interval to close connections in the connection pool in seconds"/>
 	<!--remote server params-->
 	<parameter name="host" description="Host name of the file server"/>
 	<parameter name="port" description="The port number of the file server"/>

--- a/src/main/resources/uischema/sftp.json
+++ b/src/main/resources/uischema/sftp.json
@@ -103,6 +103,17 @@
                     "required": "false",
                     "helpTip": "Set to true if you want to avoid permission check."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "connectionPoolTimeout",
+                    "displayName": "Connection Pool Timeout",
+                    "inputType": "string",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Interval to close connections in the connection pool in seconds"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
 This PR will include a new parameter to file connector under SFTP connections to invalidate the connections in the pool if the user specify a connection pool timeout value. 
To configure the connection pool timeout, the user need to add the following parameter and the timeout in seconds

```<connectionPoolTimeout>3600</connectionPoolTimeout> ```
The above config should disconnect the created connection pool cache in each hour

This setting will appear in the connection config UI in the studio under SFTP connections
