### PR TITLE
Introduce proper pooling support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.file</artifactId>
-    <version>4.0.13</version>
+    <version>4.0.14</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For esb-connector-file</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
         <synapse.version>2.1.7-wso2v227</synapse.version>
-        <carbon.mediation.version>4.7.99</carbon.mediation.version>
+        <carbon.mediation.version>4.7.59</carbon.mediation.version>
         <json.version>2.0.0.wso2v1</json.version>
         <org.testng.version>6.1.1</org.testng.version>
         <jets3t.version>0.9.4</jets3t.version>

--- a/src/main/java/org/wso2/carbon/connector/connection/SFTPConnectionFactory.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/SFTPConnectionFactory.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.connector.connection;
+
+import org.wso2.carbon.connector.core.pool.ConnectionFactory;
+import org.wso2.carbon.connector.pojo.ConnectionConfiguration;
+
+public class SFTPConnectionFactory implements ConnectionFactory  {
+    private ConnectionConfiguration connectionConfiguration;
+    public SFTPConnectionFactory(ConnectionConfiguration connectionConfiguration) {
+        this.connectionConfiguration = connectionConfiguration;
+    }
+    @Override
+    public Object makeObject() throws Exception {
+        FileSystemHandler fileSystemConnection = new FileSystemHandler(connectionConfiguration);
+        return fileSystemConnection;
+    }
+
+    @Override
+    public void destroyObject(Object connection) throws Exception {
+        ((FileSystemHandler) connection).close();
+    }
+
+    @Override
+    public boolean validateObject(Object connection) {
+        return true;
+    }
+
+    @Override
+    public void activateObject(Object o) throws Exception {
+        // Nothing to do here
+    }
+
+    @Override
+    public void passivateObject(Object o) throws Exception {
+        // Nothing to do here
+    }
+}

--- a/src/main/java/org/wso2/carbon/connector/operations/CreateDirectory.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/CreateDirectory.java
@@ -45,19 +45,22 @@ public class CreateDirectory extends AbstractConnector {
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
 
-        ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
         String folderPath = null;
         FileObject folderToCreate = null;
+
+        FileSystemHandler fileSystemHandlerConnection = null;
+        ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
+        String connectionName = Utils.getConnectionName(messageContext);
+        String connectorName = Const.CONNECTOR_NAME;
         try {
 
-            String connectionName = Utils.getConnectionName(messageContext);
-            FileSystemHandler fileSystemHandler = (FileSystemHandler) handler
+            fileSystemHandlerConnection = (FileSystemHandler) handler
                     .getConnection(Const.CONNECTOR_NAME, connectionName);
             folderPath = (String) ConnectorUtils.
                     lookupTemplateParamater(messageContext, Const.DIRECTORY_PATH);
-            FileSystemManager fsManager = fileSystemHandler.getFsManager();
-            FileSystemOptions fso = fileSystemHandler.getFsOptions();
-            folderPath = fileSystemHandler.getBaseDirectoryPath() + folderPath;
+            FileSystemManager fsManager = fileSystemHandlerConnection.getFsManager();
+            FileSystemOptions fso = fileSystemHandlerConnection.getFsOptions();
+            folderPath = fileSystemHandlerConnection.getBaseDirectoryPath() + folderPath;
             folderToCreate = fsManager.resolveFile(folderPath, fso);
             //create folder if it doesn't exist
             folderToCreate.createFolder();
@@ -85,6 +88,11 @@ public class CreateDirectory extends AbstractConnector {
                     log.error(Const.CONNECTOR_NAME
                             + ":Error while closing file object while creating directory "
                             + folderToCreate);
+                }
+            }
+            if (handler.getStatusOfConnection(Const.CONNECTOR_NAME, connectionName)) {
+                if (fileSystemHandlerConnection != null) {
+                    handler.returnConnection(connectorName, connectionName, fileSystemHandlerConnection);
                 }
             }
         }

--- a/src/main/java/org/wso2/carbon/connector/operations/RenameFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RenameFiles.java
@@ -49,16 +49,18 @@ public class RenameFiles extends AbstractConnector {
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
 
-        ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
         String fileOrFolderPath = null;
         String newName;
         FileObject fileToRename = null;
         boolean overwrite;
         FileOperationResult result;
+        FileSystemHandler fileSystemHandlerConnection = null;
+        ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
+        String connectionName = Utils.getConnectionName(messageContext);
+        String connectorName = Const.CONNECTOR_NAME;
         try {
 
-            String connectionName = Utils.getConnectionName(messageContext);
-            FileSystemHandler fileSystemHandler = (FileSystemHandler) handler
+            fileSystemHandlerConnection = (FileSystemHandler) handler
                     .getConnection(Const.CONNECTOR_NAME, connectionName);
             overwrite = Boolean.parseBoolean((String) ConnectorUtils.
                     lookupTemplateParamater(messageContext, OVERWRITE_PARAM));
@@ -66,9 +68,9 @@ public class RenameFiles extends AbstractConnector {
                     lookupTemplateParamater(messageContext, RENAME_TO_PARAM);
             fileOrFolderPath = (String) ConnectorUtils.
                     lookupTemplateParamater(messageContext, Const.FILE_OR_DIRECTORY_PATH);
-            FileSystemManager fsManager = fileSystemHandler.getFsManager();
-            FileSystemOptions fso = fileSystemHandler.getFsOptions();
-            fileOrFolderPath = fileSystemHandler.getBaseDirectoryPath() + fileOrFolderPath;
+            FileSystemManager fsManager = fileSystemHandlerConnection.getFsManager();
+            FileSystemOptions fso = fileSystemHandlerConnection.getFsOptions();
+            fileOrFolderPath = fileSystemHandlerConnection.getBaseDirectoryPath() + fileOrFolderPath;
             fileToRename = fsManager.resolveFile(fileOrFolderPath, fso);
 
             //path after rename
@@ -136,6 +138,12 @@ public class RenameFiles extends AbstractConnector {
                             + fileToRename);
                 }
             }
+            if (handler.getStatusOfConnection(Const.CONNECTOR_NAME, connectionName)) {
+                if (fileSystemHandlerConnection != null) {
+                    handler.returnConnection(connectorName, connectionName, fileSystemHandlerConnection);
+                }
+            }
+
         }
     }
 

--- a/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.connector.pojo;
 
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.connector.connection.FileServerProtocol;
+import org.wso2.carbon.connector.core.pool.Configuration;
 import org.wso2.carbon.connector.exception.InvalidConfigurationException;
 import org.wso2.carbon.connector.utils.Const;
 
@@ -30,6 +31,8 @@ import org.wso2.carbon.connector.utils.Const;
 public class ConnectionConfiguration {
 
     private String connectionName;
+
+    private Configuration configuration;
 
     private FileServerProtocol protocol;
     /**
@@ -49,6 +52,16 @@ public class ConnectionConfiguration {
      */
     private RemoteServerConfig remoteServerConfig;
     private boolean isRemote = false;
+
+    private long poolConnectionAgedTimeout;
+
+    public ConnectionConfiguration() {
+
+        this.configuration = new Configuration();
+        // Set default values
+        this.configuration.setExhaustedAction("WHEN_EXHAUSTED_FAIL");
+        this.configuration.setTestOnBorrow(true);
+    }
 
     public String getConnectionName() {
         return connectionName;
@@ -127,5 +140,83 @@ public class ConnectionConfiguration {
 
     public void setRemoteServerConfig(RemoteServerConfig remoteServerConfig) {
         this.remoteServerConfig = remoteServerConfig;
+    }
+    public int getMaxActiveConnections() {
+
+        return configuration.getMaxActiveConnections();
+    }
+
+    public void setMaxActiveConnections(int maxActiveConnections) {
+
+        this.configuration.setMaxActiveConnections(maxActiveConnections);
+    }
+
+    public int getMaxIdleConnections() {
+
+        return configuration.getMaxIdleConnections();
+    }
+
+    public void setMaxIdleConnections(int maxIdleConnections) {
+
+        this.configuration.setMaxIdleConnections(maxIdleConnections);
+    }
+
+    public long getMaxWaitTime() {
+
+        return configuration.getMaxWaitTime();
+    }
+
+    public void setMaxWaitTime(long maxWaitTime) {
+
+        this.configuration.setMaxWaitTime(maxWaitTime);
+    }
+
+    public long getMinEvictionTime() {
+
+        return configuration.getMinEvictionTime();
+    }
+
+    public void setMinEvictionTime(long minEvictionTime) {
+
+        this.configuration.setMinEvictionTime(minEvictionTime);
+    }
+
+    public long getEvictionCheckInterval() {
+
+        return configuration.getEvictionCheckInterval();
+    }
+
+    public void setEvictionCheckInterval(long evictionCheckInterval) {
+
+        this.configuration.setEvictionCheckInterval(evictionCheckInterval);
+    }
+
+    public String getExhaustedAction() {
+
+        return configuration.getExhaustedAction();
+    }
+
+    public void setExhaustedAction(String exhaustedAction) {
+
+        this.configuration.setExhaustedAction(exhaustedAction);
+    }
+
+    public Configuration getConfiguration() {
+
+        return configuration;
+    }
+
+    public void setConfiguration(Configuration configuration) {
+
+        this.configuration = configuration;
+    }
+
+    public long getPoolConnectionAgedTimeout() {
+        return poolConnectionAgedTimeout;
+    }
+
+    public void setPoolConnectionAgedTimeout(long poolConnectionAgedTimeout) {
+        this.configuration.setPoolConnectionAgedTimeout(poolConnectionAgedTimeout);
+        this.poolConnectionAgedTimeout = poolConnectionAgedTimeout;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/utils/Const.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Const.java
@@ -56,6 +56,7 @@ public final class Const {
 
     public static final String SFTP_CONNECTION_TIMEOUT = "sftpConnectionTimeout";
     public static final String SFTP_SESSION_TIMEOUT = "sftpSessionTimeout";
+    public static final String SFTP_POOL_CONNECTION_AGED_TIMEOUT = "sftpPoolConnectionAgedTimeout";
     public static final String STRICT_HOST_KEY_CHECKING = "strictHostKeyChecking";
     public static final String PRIVATE_KEY_FILE_PATH = "privateKeyFilePath";
     public static final String PRIVATE_KEY_PASSWORD = "privateKeyPassword";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -47,6 +47,7 @@
 	<parameter name="privateKeyFilePath" description="path to private key file"/>
 	<parameter name="privateKeyPassword" description="Passphrase of the private key"/>
 	<parameter name="setAvoidPermission" description="Sets whether to avoid file permission check."/>
+	<parameter name="sftpPoolConnectionAgedTimeout" description="Interval to close connections in the connection pool in seconds"/>
 	<sequence>
 		<property name="name" expression="$func:name"/>
 		<class name="org.wso2.carbon.connector.operations.FileConfig" />

--- a/src/main/resources/uischema/sftp.json
+++ b/src/main/resources/uischema/sftp.json
@@ -103,6 +103,17 @@
                     "required": "false",
                     "helpTip": "Set to true if you want to avoid permission check."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "sftpPoolConnectionAgedTimeout",
+                    "displayName": "Connection Pool Aged Timeout",
+                    "inputType": "string",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Interval to close connections in the connection pool in seconds"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2-extensions/esb-connector-file/issues/190

With this what we changed in the design is that we have used a connection pool for each destination rather than the previously used single cached connection.

So when there is more concurrency the number of connections will increase and improve the performance.

Also, the main feature was to support "Aged Connection Timeout " for pools
where you can configure "sftpPoolConnectionAgedTimeout" property in init section and define a life span for each pool.
The difference here is with this timeout unlike other timeouts we could gracefully clear existing connections while handing over the new operations to another pool once the time out reached.


