### PR TITLE
Fixed Issue#192

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
@@ -377,7 +377,7 @@ public class WriteFile extends AbstractConnector {
                     IOUtils.write(config.contentToWrite, out, config.encoding);
                 } else {
                     IOUtils.write(config.contentToWrite, out, Const.DEFAULT_ENCODING);
-                }
+                } 
             }
             return out.getByteCount();
         } finally {

--- a/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
@@ -372,11 +372,12 @@ public class WriteFile extends AbstractConnector {
                 // Write binary content decoded from a base64 string
                 byte[] decoded = Base64.getDecoder().decode(config.contentToWrite);
                 out.write(decoded);
-            }
-            if (StringUtils.isNotEmpty(config.encoding)) {
-                IOUtils.write(config.contentToWrite, out, config.encoding);
             } else {
-                IOUtils.write(config.contentToWrite, out, Const.DEFAULT_ENCODING);
+                if (StringUtils.isNotEmpty(config.encoding)) {
+                    IOUtils.write(config.contentToWrite, out, config.encoding);
+                } else {
+                    IOUtils.write(config.contentToWrite, out, Const.DEFAULT_ENCODING);
+                }
             }
             return out.getByteCount();
         } finally {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves Issue#192

## Goals
Fix the error: If the incoming binary file content sent as base64 encoded string that is created with file write operation, the encoded string is seen at the end of the file.

## Approach
Fix the error in performContentWrite method of the WriteFile class.