### PR TITLE
Considering FSO params when setting the values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.file</artifactId>
-    <version>4.0.14</version>
+    <version>4.0.15</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For esb-connector-file</name>
     <url>http://wso2.org</url>
@@ -30,7 +30,7 @@
     <properties>
         <connector.name>file</connector.name>
 <!--        <commons.vfs.version>2.6.0</commons.vfs.version>-->
-        <commons.vfs.version>2.2-wso2v6</commons.vfs.version>
+        <commons.vfs.version>2.2.0-wso2v9.3</commons.vfs.version>
         <integration.base.version>1.0.2</integration.base.version>
         <product.ei.version>6.1.1</product.ei.version>
         <carbon.kernel.version>4.4.17</carbon.kernel.version>
@@ -38,7 +38,7 @@
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
         <synapse.version>2.1.7-wso2v227</synapse.version>
-        <carbon.mediation.version>4.7.59</carbon.mediation.version>
+        <carbon.mediation.version>4.7.99.10</carbon.mediation.version>
         <json.version>2.0.0.wso2v1</json.version>
         <org.testng.version>6.1.1</org.testng.version>
         <jets3t.version>0.9.4</jets3t.version>

--- a/src/main/java/org/wso2/carbon/connector/connection/FTPFileSystemSetup.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/FTPFileSystemSetup.java
@@ -36,6 +36,7 @@ public class FTPFileSystemSetup implements ProtocolBasedFileSystemSetup {
         FtpFileSystemConfigBuilder ftpConfigBuilder = FtpFileSystemConfigBuilder.getInstance();
         ftpConfigBuilder.setPassiveMode(fso, ftpConnectionConfig.isPassive());
         ftpConfigBuilder.setConnectTimeout(fso, ftpConnectionConfig.getConnectionTimeout());
+        ftpConfigBuilder.setRetryCount(fso, fsConfig.getRetryCount());
         ftpConfigBuilder.setSoTimeout(fso, ftpConnectionConfig.getSocketTimeout());
         ftpConfigBuilder.setUserDirIsRoot(fso, ftpConnectionConfig.isUserDirIsRoot());
 

--- a/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
@@ -112,6 +112,9 @@ public class FileConfig extends AbstractConnector implements ManagedLifecycle {
                 lookupTemplateParamater(msgContext, Const.MAX_FAILURE_RETRY_COUNT);
         String sftpPoolConnectionAgedTimeout = (String) ConnectorUtils.lookupTemplateParamater(msgContext, Const.SFTP_POOL_CONNECTION_AGED_TIMEOUT);
 
+        String retryCount = (String) ConnectorUtils.
+                lookupTemplateParamater(msgContext, Const.RETRY_COUNT);
+
         ConnectionConfiguration connectionConfig = new ConnectionConfiguration();
         if (sftpPoolConnectionAgedTimeout != null) {
             try {
@@ -119,6 +122,13 @@ public class FileConfig extends AbstractConnector implements ManagedLifecycle {
             } catch (NumberFormatException numberFormatException) {
                 log.warn("Ignore setting SFTP_POOL_CONNECTION_AGED_TIMEOUT property. Since the value is not set " +
                         "properly");
+            }
+        }
+        if (retryCount != null) {
+            try {
+                connectionConfig.setRetryCount(Integer.parseInt(retryCount));
+            } catch (NumberFormatException numberFormatException) {
+                log.warn("Ignore setting RETRY_COUNT property. Since the value is not set properly");
             }
         }
         connectionConfig.setConnectionName(connectionName);

--- a/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
@@ -219,4 +219,13 @@ public class ConnectionConfiguration {
         this.configuration.setPoolConnectionAgedTimeout(poolConnectionAgedTimeout);
         this.poolConnectionAgedTimeout = poolConnectionAgedTimeout;
     }
+
+    public int getRetryCount() {
+        return configuration.getRetryCount();
+    }
+
+    public void setRetryCount(int retryCount) {
+        this.configuration.setRetryCount(retryCount);
+    }
+
 }

--- a/src/main/java/org/wso2/carbon/connector/utils/Const.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Const.java
@@ -36,6 +36,7 @@ public final class Const {
     public static final String WORKING_DIR = "workingDir";
     public static final String FILE_LOCK_SCHEME = "fileLockScheme";
     public static final String MAX_FAILURE_RETRY_COUNT = "maxFailureRetryCount";
+    public static final String RETRY_COUNT = "retryCount";
     public static final String SET_AVOID_PERMISSION = "setAvoidPermission";
 
     public static final String HOST = "host";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -33,6 +33,7 @@
 	<parameter name="isPassive" description="True if to enter into passive mode"/>
 	<parameter name="ftpConnectionTimeout" description="Timeout in milisec for initial control connection"/>
 	<parameter name="ftpSocketTimeout" description="Socket timeout for FTP client"/>
+	<parameter name="retryCount" description="Retry count for FTP client"/>
 	<!--FTPS specific params-->
 	<parameter name="keyStorePath" description="Path to keyStore"/>
 	<parameter name="keyStorePassword" description="KeyStore password"/>

--- a/src/main/resources/uischema/ftp.json
+++ b/src/main/resources/uischema/ftp.json
@@ -128,6 +128,17 @@
           {
             "type": "attribute",
             "value": {
+              "name": "retryCount",
+              "displayName": "retryCount for FTP Connection",
+              "inputType": "stringOrExpression",
+              "defaultValue": "5",
+              "required": "no",
+              "helpTip":"Number of times to retry for FTP Connection"
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "ftpSocketTimeout",
               "displayName": "FTP Socket Timeout",
               "inputType": "stringOrExpression",


### PR DESCRIPTION


## Purpose
Previously we were not considering FSO params when setting the values (only considering the query params) of FileConnectors

Fixes: https://github.com/wso2/api-manager/issues/1969