### PR TITLE
Support invalidating connections when related local entry changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.file</artifactId>
-    <version>4.0.18</version>
+    <version>4.0.19</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For esb-connector-file</name>
     <url>http://wso2.org</url>
@@ -38,7 +38,7 @@
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
         <synapse.version>2.1.7-wso2v227</synapse.version>
-        <carbon.mediation.version>4.7.99.10</carbon.mediation.version>
+        <carbon.mediation.version>4.7.183</carbon.mediation.version>
         <json.version>2.0.0.wso2v1</json.version>
         <org.testng.version>6.1.1</org.testng.version>
         <jets3t.version>0.9.4</jets3t.version>

--- a/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FileConfig.java
@@ -72,10 +72,22 @@ public class FileConfig extends AbstractConnector implements ManagedLifecycle {
 
             ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
             if ("SFTP".equalsIgnoreCase(configuration.getProtocol().getName())) {
-                handler.createConnection(Const.CONNECTOR_NAME, tenantSpecificConnectionName, new SFTPConnectionFactory(configuration), configuration.getConfiguration());
+                try {
+                    handler.createConnection(Const.CONNECTOR_NAME, tenantSpecificConnectionName,
+                            new SFTPConnectionFactory(configuration), configuration.getConfiguration(), messageContext);
+                } catch (NoSuchMethodError e) {
+                    //Running in a version of Mediation that does not support local entry undeploy callback.
+                    // Hence Ignoring
+                }
             } else if (!handler.checkIfConnectionExists(connectorName, tenantSpecificConnectionName)) {
                 FileSystemHandler fileSystemHandler = new FileSystemHandler(configuration);
-                handler.createConnection(Const.CONNECTOR_NAME, tenantSpecificConnectionName, fileSystemHandler);
+                try {
+                    handler.createConnection(Const.CONNECTOR_NAME, tenantSpecificConnectionName, fileSystemHandler
+                            , messageContext);
+                } catch (NoSuchMethodError e) {
+                    //Running in a version of Mediation that does not support local entry undeploy callback.
+                    // Hence Ignoring
+                }
             }
         } catch (InvalidConfigurationException e) {
 


### PR DESCRIPTION


## Purpose
I introduced an enhancement to the way we handle connections in relation to local entries.
A mechanism was established where the key associated with a localEntry is passed from the InvokeMediator
to the TemplateMediator then further propagated to the TemplateContext, ensuring that the specific localEntry is accessible from the connection handling code.

With the availability of the localEntry key, each active connection(dynamic/static) has been bound to its respective localEntry in a map.

So when a localEntry is undeployed or removed, this change is detected by the Synapse Observer, and the connections associated with that specific localEntry are invalidated.

 Fixes: https://github.com/wso2/micro-integrator/issues/3002