### PR TITLE
Cleanup code to access process ID. Requires JDK 1.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The File [Connector](https://docs.wso2.com/display/EI650/Working+with+Connectors
 |  [2.0.0](https://github.com/wso2-extensions/esb-connector-file/tree/org.wso2.carbon.connector.fileconnector-2.0.0)        |    ESB 4.8.1 |
 |  [1.0.0](https://github.com/wso2-extensions/esb-connector-file/tree/org.wso2.carbon.connector.fileconnector-1.0.0)        |    ESB 4.8.1 |
 
+Requires JDK 1.9+
 
 ## Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,8 +210,8 @@
                 <version>3.7.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.9</source>
+                    <target>1.9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/wso2/carbon/connector/filelock/GlobalFileLock.java
+++ b/src/main/java/org/wso2/carbon/connector/filelock/GlobalFileLock.java
@@ -123,20 +123,10 @@ public class GlobalFileLock implements FileLock {
         try {
             hostName = InetAddress.getLocalHost().getHostName();
             hostAddress = InetAddress.getLocalHost().getHostAddress();
-            java.lang.management.RuntimeMXBean runtime =
-                    java.lang.management.ManagementFactory.getRuntimeMXBean();
-            java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
-            jvm.setAccessible(true);
-            sun.management.VMManagement mgmt =
-                    (sun.management.VMManagement) jvm.get(runtime);
-            java.lang.reflect.Method pid_method =
-                    mgmt.getClass().getDeclaredMethod("getProcessId");
-            pid_method.setAccessible(true);
-
-            int pid = (Integer) pid_method.invoke(mgmt);
-            processId = Integer.toString(pid);
+            long pid = ProcessHandle.current().pid();
+            processId = String.valueOf(pid);
         } catch (Exception e) {
-            log.error("[FileConnector] Error while getting information to write to lock file.");
+            log.error("[FileConnector] Error while getting information to write to lock file.", e);
         }
         String lockFileContent = hostName +
                 Const.NEW_LINE +


### PR DESCRIPTION
## Purpose
Running the file connector on JDK 17 leaves the message "[FileConnector] Error while getting information to write to lock file." on the logs. 
Investigation of the issue indicates it is due to restriction on access to sun.management module

Error message:
Unable to make field private final sun.management.VMManagement sun.management.RuntimeImpl.jvm accessible: module java.management does not "opens sun.management" to unnamed module @18233da2 java.lang.reflect.InaccessibleObjectException: Unable to make field private final sun.management.VMManagement sun.management.RuntimeImpl.jvm accessible: module java.management does not "opens sun.management" to unnamed module @18233da2
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
        at org.wso2.carbon.connector.filelock.GlobalFileLock.writeToLockFile(GlobalFileLock.java:)

## Goals
Replaces the "hacky" implementation with standard API


## Release note
Requires JDK 1.9+
