### PR TITLE
Fix the null pointer when closing the file system if the connection fails to establish

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -10,7 +10,7 @@
     ],
     "releases": [
         {
-            "tagName": "v4.0.29",
+            "tagName": "v4.0.31",
             "products": [
                 "EI 7.1.0",
                 "EI 6.6.0",

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.file</artifactId>
-    <version>4.0.30</version>
+    <version>4.0.31</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For esb-connector-file</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/connector/utils/Utils.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/Utils.java
@@ -311,10 +311,13 @@ public class Utils {
     public static void closeFileSystem(FileObject fileObject) {
         try {
             //Close the File system if it is not already closed
-            if (fileObject != null && fileObject.getParent() != null && fileObject.getParent().getFileSystem() != null) {
-                fileObject.getParent().getFileSystem().getFileSystemManager().closeFileSystem(fileObject.getFileSystem());
+            if (fileObject != null) {
+                if (fileObject.getParent() != null && fileObject.getParent().getFileSystem() != null) {
+                    fileObject.getParent().getFileSystem().getFileSystemManager()
+                            .closeFileSystem(fileObject.getFileSystem());
+                }
+                fileObject.close();
             }
-            fileObject.close();
         } catch (FileSystemException warn) {
             String message = "Error on closing the file: " + fileObject.getName().getPath();
             log.warn(message, warn);


### PR DESCRIPTION
## Purpose
When the connection fails to establish, still it tries to close the file system which causes a null pointer exception. This PR is to fix that. 
Fixes: https://github.com/wso2/micro-integrator/issues/3570

### Approach

Check if the file object is not null before trying to close it.