### PR TITLE
Fix OutOfMemoryError when streaming large files via file.write

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/WriteFile.java
@@ -662,7 +662,7 @@ public class WriteFile extends AbstractConnectorOperation {
                 } else {
                     outputStream = new CountingOutputStream(targetFile.getContent().getOutputStream(append));
                 }
-                messageFormatter.writeTo(axis2MessageContext, format, outputStream, true);
+                messageFormatter.writeTo(axis2MessageContext, format, outputStream, !config.enableStreaming);
                 writtenByesCount = outputStream.getByteCount();
             } finally {
                 if (outputStream != null) {


### PR DESCRIPTION
## Purpose

This PR addresses an issue where downloading and writing large files using the `file.write` function results in a `java.lang.OutOfMemoryError`, even when the `enableStreaming` parameter is explicitly set to `true`. 

## Goals

The goal of this fix is to prevent JVM heap exhaustion during large file transfers by allowing the raw network `InputStream` to be fully consumed, streamed directly to the file system, and immediately discarded when streaming is enabled. It also guarantees backward compatibility for integration flows that have `enableStreaming` flag set to `false`

## Approach

Currently, in `WriteFile.java`, the `MessageFormatter.writeTo()` method is invoked with the `preserve` argument hardcoded to `true`: `messageFormatter.writeTo(axis2MessageContext, format, outputStream, true);`

Because `preserve` is `true`, the `ExpandingMessageFormatter` skips marking the `StreamingOnRequestDataSource` for "last use". Consequently, to preserve the "read-once" network stream for subsequent mediators, `BinaryRelayBuilder.readAllFromInputSteam()` is triggered, aggressively caching the entire payload in a `ByteArrayOutputStream`. For massive files, this immediately triggers an OOM crash.

**Implementation**
This PR modifies mentioned line to infer the `preserve` flag logically based on the user's streaming configuration:

* **`enableStreaming=true`:** The `preserve` flag evaluates to `false`. The payload is streamed natively to disk and discarded, maintaining a flat memory footprint.
* **`enableStreaming=false`:** The `preserve` flag evaluates to `true`, maintaining the same behavior for smaller files.

**Potential improvement**

While this patch fixes the immediate OOM streaming issue, a future improvement could introduce an explicit `preservePayload` boolean parameter to the `write` function configuration. This would cleanly decouple the transfer mechanism (`enableStreaming`) from the payload lifecycle (`preservePayload`), giving integration developers explicit control over when the message body is kept alive in the integration flow.

## Evidence

Demo project: [example-project.zip](https://github.com/user-attachments/files/27416559/example-project.zip)

**Stacktrace:**

```text
[2026-05-05 22:06:40,676] ERROR {org.apache.axis2.transport.base.threads.NativeWorkerPool} - Uncaught exception java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3541)
	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:100)
	at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:132)
	at org.wso2.carbon.relay.BinaryRelayBuilder.readAllFromInputSteam(BinaryRelayBuilder.java:42)
	at org.wso2.carbon.relay.StreamingOnRequestDataSource.getInputStream(StreamingOnRequestDataSource.java:59)
	at javax.activation.DataHandler.writeTo(DataHandler.java:318)
	at org.wso2.carbon.relay.ExpandingMessageFormatter.findAndWrite2OutputStream(ExpandingMessageFormatter.java:196)
	at org.wso2.carbon.relay.ExpandingMessageFormatter.writeTo(ExpandingMessageFormatter.java:97)
	at org.wso2.carbon.connector.operations.WriteFile.performBodyWrite(WriteFile.java:665)
	at org.wso2.carbon.connector.operations.WriteFile.writeToFile(WriteFile.java:472)
	at org.wso2.carbon.connector.operations.WriteFile.execute(WriteFile.java:167)
	at org.wso2.integration.connector.core.AbstractConnectorOperation.connect(AbstractConnectorOperation.java:53)
	at org.wso2.integration.connector.core.AbstractConnector.mediate(AbstractConnector.java:46)
	at org.apache.synapse.mediators.ext.ClassMediator.updateInstancePropertiesAndMediate(ClassMediator.java:253)
	at org.apache.synapse.mediators.ext.ClassMediator.mediate(ClassMediator.java:115)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
	at org.apache.synapse.mediators.template.TemplateMediator.mediate(TemplateMediator.java:147)
	at org.apache.synapse.mediators.template.InvokeMediator.mediate(InvokeMediator.java:202)
	at org.apache.synapse.mediators.template.InvokeMediator.mediate(InvokeMediator.java:117)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
	at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:242)
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.mediateFromContinuationStateStack(Axis2SynapseEnvironment.java:857)
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:330)
	at org.apache.synapse.core.axis2.SynapseCallbackReceiver.handleMessage(SynapseCallbackReceiver.java:677)
	at org.apache.synapse.core.axis2.SynapseCallbackReceiver.receive(SynapseCallbackReceiver.java:212)
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
	at org.apache.synapse.transport.passthru.ClientWorker.run(ClientWorker.java:339)
	at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.runWith(Thread.java:1596)
```

**jconsole (during OOM before fix)**
<img width="1919" height="1030" alt="screenshot-1" src="https://github.com/user-attachments/assets/bb4462bf-6ece-4b9f-a014-8875fab72faf" />

**jconsole (with fix applied - 2GB file downloaded and saved correctly)**
<img width="1919" height="1027" alt="screenshot-2" src="https://github.com/user-attachments/assets/84870105-b1b9-4572-9adf-4c8416e53fc6" />
