### PR TITLE
Fix an issue in file connector move operation

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/MoveFiles.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MoveFiles.java
@@ -284,17 +284,23 @@ public class MoveFiles extends AbstractConnectorOperation {
 
         if (!overWrite && destinationFile.exists()) {
             return false;
-        } else {
+        }
+
+        FileObject parent = destinationFile.getParent();
+        if (parent != null && !parent.exists()) {
             if (createNonExistingParents) {
+                // calling createFolder on destinationFile creates all the non-existing
+                // parent directories as well.
                 destinationFile.createFolder();
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Parent directory creation is skipped.");
-                }
+                throw new FileSystemException("Parent directory: " + parent.getName()
+                    + " does not exist and createParentDirectories is set to false");
             }
-            srcFile.moveTo(destinationFile);
-            return true;
+        } else if (log.isDebugEnabled()) {
+            log.debug("Parent directory creation is skipped.");
         }
+        srcFile.moveTo(destinationFile);
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Fix an issue in the file connector to stop creating the parent directory if it exists.
Fixes wso2/product-integrator-mi/issues/4934